### PR TITLE
Write my.cnf details on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.0 (2020-63-23)
+### Changed
+- Added and use `mintel` user
+- Added `docker-entrypoint.sh` to write out the `$HOME/.my.cnf` file on startup from vault
+
 ## 0.3.0 (2020-63-23)
 ### Changed
 - Renamed repo to `k8s-mysqlclient`

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,11 @@ COPY --from=gcr.io/google_containers/pause-amd64:3.2 /pause /
 COPY --from=banzaicloud/vault-env:1.3.2 /usr/local/bin/vault-env /usr/local/bin/
 
 RUN apk add --no-cache mysql-client
+RUN adduser -D -s /bin/sh -u 1000 mintel --home /home/mintel
 
-ENTRYPOINT ["mysql"]
+COPY docker-entrypoint.sh /
+
+USER 1000
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/pause"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+if [ -n "${KUBERNETES_SERVICE_HOST}" ]; then
+
+  DB_NAME=$(vault-env env | grep DB_NAME | cut -d"=" -f2)
+  DB_USER=$(vault-env env | grep DB_USER | cut -d"=" -f2)
+  DB_PASSWORD=$(vault-env env | grep DB_PASSWORD | cut -d"=" -f2)
+
+cat << EOF > /home/mintel/.my.cnf
+[client]
+
+database=$DB_NAME
+user=$DB_USER
+password=$DB_PASSWORD
+host=127.0.0.1
+EOF
+    
+fi
+
+exec "$@"


### PR DESCRIPTION
## 0.4.0 (2020-63-23)
### Changed
- Added and use `mintel` user
- Added `docker-entrypoint.sh` to write out the `$HOME/.my.cnf` file on startup from vault


---

It's fairly common now that users want to pipe commands to mysql and redirect output to local disk.

This becomes complicated when working with `vault-env` in my view, so writing the `my.cnf` file on pod-start really simplifies this.

So now you can do:

```
kubectl exec -it mypod-6hh5t -- mysql -e "show tables;"  > /tmp/somel-local-file.txt
kubectl exec -it mypod-6hh5t mysql
```